### PR TITLE
New exceptions

### DIFF
--- a/bookwormDB/CreateDatabase.py
+++ b/bookwormDB/CreateDatabase.py
@@ -71,7 +71,7 @@ class DB:
         
     def connect(self, setengine=True):
         #These scripts run as the Bookworm _Administrator_ on this machine; defined by the location of this my.cnf file.
-        self.conn = MySQLdb.connect(read_default_file="~/.my.cnf",use_unicode='True', charset='utf8', db='', local_infile=1)
+        self.conn = MySQLdb.connect(read_default_file=os.path.expanduser("~/.my.cnf"),use_unicode='True', charset='utf8', db='', local_infile=1)
         cursor = self.conn.cursor()
         cursor.execute("CREATE DATABASE IF NOT EXISTS %s" % self.dbname)
         #Don't use native query attribute here to avoid infinite loops
@@ -166,7 +166,9 @@ class BookwormSQLDatabase:
         import ConfigParser
         # This should be using the global configparser module, not the custom code here
         config = ConfigParser.ConfigParser(allow_no_value=True)
-        config.read(["~/.my.cnf","/etc/my.cnf","/etc/mysql/my.cnf","bookworm.cnf"])
+        files = config.read([os.path.expanduser("~/.my.cnf"), "/etc/my.cnf",
+                            "/etc/mysql/my.cnf", "bookworm.cnf"])
+        logging.debug("Config successfully read: " + str(files))
         username=config.get("client","user")
         password=config.get("client","password")
         self.db.query("GRANT SELECT ON %s.* TO '%s'@'localhost' IDENTIFIED BY '%s'" % (self.dbname,username,password))

--- a/bookwormDB/SQLAPI.py
+++ b/bookwormDB/SQLAPI.py
@@ -7,6 +7,8 @@ import copy
 import MySQLdb
 import hashlib
 import logging
+from bwExceptions import BookwormException
+
 """
 # There are 'fast' and 'full' tables for books and words;
 # that's so memory tables can be used in certain cases for fast, hashed
@@ -27,7 +29,6 @@ general_prefs["default"] = {"fastcat": "fastcat",
                             "fullcat": "catalog",
                             "fullword": "words",
                             "read_default_file": "/etc/mysql/my.cnf"}
-
 
 class DbConnect(object):
     # This is a read-only account
@@ -543,6 +544,11 @@ class userquery:
 
         needsBigrams = (self.max_word_length == 2 or re.search("words2", self.selections))
         needsUnigrams = self.max_word_length == 1 or re.search("[^h][^a][^s]word", self.selections)
+
+        if self.max_word_length > 2:
+            err = dict(code=400, message="Phrase is longer than what Bookworm supports")
+            raise BookwormException(err)
+
         needsTopics = bool(re.search("topic", self.selections)) or ("topic" in self.limits.keys())
 
         if needsBigrams:

--- a/bookwormDB/bin/dbbindings-flask.py
+++ b/bookwormDB/bin/dbbindings-flask.py
@@ -16,6 +16,14 @@ def index():
         return "Need query or queryTerms argument"
     return main(JSONinput)
 
+@app.route('/debug')
+def debug_api():
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    JSONinput = request.args.get('queryTerms') or request.args.get('query')
+    if not JSONinput:
+        return "Need query or queryTerms argument"
+    return main(JSONinput)
 
 @app.route('/debug/query')
 def debug_query():

--- a/bookwormDB/bwExceptions.py
+++ b/bookwormDB/bwExceptions.py
@@ -1,0 +1,18 @@
+'''
+This is a stub exception to identify explicitly defined Bookworm Exception.
+
+The intended usage is to raise the exception with a dict that has an error
+message, and optionally a code that matches HTTP status codes. e.g.
+
+    raise BookwormException({"message": "I'm a teapot" code:418})
+
+or more tidy for longer messages:
+    err = dict(message="I'm a teapot", code=418)
+    raise BookwormException(err)
+
+Code should be an int, not a string.
+'''
+
+
+class BookwormException(Exception):
+    pass


### PR DESCRIPTION
There is now a BookwormException which you can explicitly raise with a dict in this style: 

```python
raise BookwormException({"message": "I'm a teapot", code: 418})
```

This is sent up the stack and caught when executing a query, which will return a JSEND-style response: 

```json
	{
	" status " : "error",
	"message" : "I'm a teapot",
	"code": 418 
	}
```

The codes, as mentioned in #95, are HTTP status codes. This makes it easy for the API to format its HTTP response to match what the backend provides. This is currently in `dbbinding-flask.py` , since that's what I test with. The reason you want both the JSend response and an HTTP code is because clients parse the 
HTTP code to see if the response should be handled as an error. Eg. `request.on("error", function(error) { callback(error); })` in D3.
