### PR TITLE
PEP8 fixing and general linting

### DIFF
--- a/bookwormDB/CreateDatabase.py
+++ b/bookwormDB/CreateDatabase.py
@@ -1,13 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import subprocess
 import MySQLdb
 import re
-import sys
 import json
 import os
-from variableSet import dataField
 from variableSet import variableSet
 from variableSet import splitMySQLcode
 from bookwormDB.configuration import Configfile
@@ -75,15 +72,15 @@ class DB:
         conf.read_config_files()
 
         self.conn = MySQLdb.connect(
-            user         = conf.config.get("client","user"),
-            passwd       = conf.config.get("client","password"),
-            use_unicode  = 'True',
-            charset      = 'utf8',
-            db           = '',
-            local_infile = 1)
+            user=conf.config.get("client","user"),
+            passwd=conf.config.get("client","password"),
+            use_unicode='True',
+            charset='utf8',
+            db='',
+            local_infile=1)
         cursor = self.conn.cursor()
         cursor.execute("CREATE DATABASE IF NOT EXISTS %s" % self.dbname)
-        #Don't use native query attribute here to avoid infinite loops
+        # Don't use native query attribute here to avoid infinite loops
         cursor.execute("SET NAMES 'utf8'")
         cursor.execute("SET CHARACTER SET 'utf8'")
         if setengine:
@@ -93,10 +90,9 @@ class DB:
                 logging.error("Forcing default engine failed. On some versions of Mysql,\
                 you may need to add \"default-storage-engine=MYISAM\" manually\
                 to the [mysqld] user in /etc/my.cnf. Trying again to connect...")
-                self.connect(setengine=False) 
+                self.connect(setengine=False)
         logging.debug("Connecting to %s" % self.dbname)
         cursor.execute("USE %s" % self.dbname)
-
 
     def query(self, sql):
         """
@@ -326,7 +322,7 @@ class BookwormSQLDatabase:
         Checks to see if memory tables need to be repopulated (by seeing if they are empty)
         and then does so if necessary.
         """
-        existingCreateCodes = self.db.query("SELECT tablename,memoryCode FROM masterTableTable").fetchall();
+        existingCreateCodes = self.db.query("SELECT tablename,memoryCode FROM masterTableTable").fetchall()
         for row in existingCreateCodes:
             """
             For each table, it checks to see if the table is currently populated; if not,
@@ -396,7 +392,7 @@ class BookwormSQLDatabase:
                 ui_components.append(newdict)
         try:
             mytime = [variable.field for variable in variables if variable.datatype=='time'][0]
-            output['default_search']  = [
+            output['default_search'] = [
                                          {
                                           "search_limits": [{"word":["test"]}],
                                           "time_measure": mytime,
@@ -433,12 +429,14 @@ class BookwormSQLDatabase:
         """
         logging.info("Updating stems from Porter algorithm...")
         from nltk import PorterStemmer
+        db = self.db
+
         stemmer = PorterStemmer()
         cursor = db.query("""SELECT word FROM words""")
         words = cursor.fetchall()
         for local in words:
-            word = ''.join(local) #Could probably take the first element of the tuple as well?
-            #Apostrophes have the save stem as the word, if they're included
+            word = ''.join(local)  # Could probably take the first element of the tuple as well?
+            # Apostrophes have the save stem as the word, if they're included
             word = word.replace("'s","")
             if re.match("^[A-Za-z]+$",word):
                 query = """UPDATE words SET stem='""" + stemmer.stem(''.join(local)) + """' WHERE word='""" + ''.join(local) + """';"""

--- a/bookwormDB/MetaParser.py
+++ b/bookwormDB/MetaParser.py
@@ -132,10 +132,11 @@ def ParseJSONCatalog(target="default",source = "default"):
                                     derive["aggregate"] == "week":
                                 k = "%s_day_month" % field["field"]
                                 dt = date(intent[0], intent[1], intent[2])
-                                #Python and javascript handle weekdays differently:
-                                #Like JS, we want to begin on Sunday with zero
+                                # Python and javascript handle weekdays differently:
+                                # Like JS, we want to begin on Sunday with zero
                                 line[k] = dt.weekday() + 1
-                                if (line[k])==7: line[k] = 0
+                                if (line[k]) == 7:
+                                    line[k] = 0
                             elif derive["resolution"] == 'month' and \
                                     derive["aggregate"] == "year":
                                 k = "%s_month_year" % field["field"]
@@ -181,20 +182,20 @@ def ParseJSONCatalog(target="default",source = "default"):
                                 inttime = DaysSinceZero(dt)
                                 line[k] = inttime
                             else:
-                                logging.warning('Resolution %s currently not supported.' %(derive['resolution']))
+                                logging.warning('Resolution %s currently not supported.' % (derive['resolution']))
                                 continue
                     except ValueError:
                         # One of out a million Times articles threw this with
                         # a year of like 111,203. It's not clear how best to
                         # handle this.
-                        logging.warning( "ERROR: %s " % line[field["field"]] + \
-                              "did not convert to proper date. Moving on...")
-                        #raise
+                        logging.warning("ERROR: %s " % line[field["field"]] +
+                                        "did not convert to proper date. Moving on...")
+                        # raise
                         pass
                     except Exception, e:
-                        logging.warning( '*'*50)
+                        logging.warning('*'*50)
                         logging.warning('ERROR: %s\nINFO: %s\n' % (str(e), e.__doc__))
-                        logging.warning( '*'*50)
+                        logging.warning('*'*50)
                 line.pop(field["field"])
         f.write('%s\n' % json.dumps(line))
         f.flush()

--- a/bookwormDB/MetaWorm.py
+++ b/bookwormDB/MetaWorm.py
@@ -1,4 +1,3 @@
-import pandas
 import json
 import copy
 import threading
@@ -84,7 +83,7 @@ class MetaQuery(object):
             
         if 'host' not in self.outside_dictionary:
             #Build a hostlist: usually just localhost a bunch of times.
-            self.outside_dictionary['host']  = hostlist(self.outside_dictionary['database'])
+            self.outside_dictionary['host'] = hostlist(self.outside_dictionary['database'])
 
         for (target, dest) in [("database","host"),("host","database")]:
             #Expand out so you can search for the same database on multiple databases, or multiple databases on the same host.

--- a/bookwormDB/SQLAPI.py
+++ b/bookwormDB/SQLAPI.py
@@ -1,6 +1,5 @@
 #!/usr/local/bin/python
 
-import sys
 import json
 import re
 import copy
@@ -895,7 +894,7 @@ class userquery:
             for string in returnarray:
                 try:
                     base = re.findall(urlRegEx, string)[0]
-                    newcore = ' <a href = "' +  base  + preface + joiner.join(self.actualWords) + '"> search inside </a>'
+                    newcore = ' <a href = "' + base + preface + joiner.join(self.actualWords) + '"> search inside </a>'
                     string = re.sub("^<td>", "", string)
                     string = re.sub("</td>$", "", string)
                     string = string+newcore
@@ -1116,13 +1115,17 @@ def where_from_hash(myhash, joiner=" AND ", comp = " = ", escapeStrings=True):
                 # Note that about a third of the code is spent on escaping strings.
                 if escapeStrings:
                     if isinstance(values[0], basestring):
-                        quotesep="'"
+                        quotesep = "'"
                     else:
                         quotesep = ""
-                    def escape(value): return MySQLdb.escape_string(to_unicode(value))
+
+                    def escape(value):
+                        return MySQLdb.escape_string(to_unicode(value))
                 else:
-                    def escape(value): return to_unicode(value)
-                    quotesep=""
+
+                    def escape(value):
+                        return to_unicode(value)
+                    quotesep = ""
                 # Note the "OR" here. There's no way to pass in a query like "year=1876 AND year=1898" as currently set up.
                 # Obviously that's no great loss, but there might be something I'm missing that would be desire a similar format somehow.
                 # (In cases where the same book could have two different years associated with it)

--- a/bookwormDB/bin/dbbindings.py
+++ b/bookwormDB/bin/dbbindings.py
@@ -17,7 +17,7 @@ def headers(method, errorcode=False):
           'X-Requested-With, X-CSRF-Token'
 
     if errorcode:
-	print "Status: %d" % errorcode
+        print "Status: %d" % errorcode
 
     if method != "return_tsv":
         print "Content-type: text/html\n"

--- a/bookwormDB/convertTSVtoJSONarray.py
+++ b/bookwormDB/convertTSVtoJSONarray.py
@@ -1,6 +1,4 @@
 import json
-import sys
-import re
 
 def convertToJSON(filename):
     """
@@ -21,5 +19,5 @@ def convertToJSON(filename):
     output.close()
 
 
-        
-        
+
+

--- a/bookwormDB/encoder.py
+++ b/bookwormDB/encoder.py
@@ -5,6 +5,7 @@ import cPickle as pickle
 import sys
 import re
 
+
 def encodeFiles(array):
     IDfile = readIDfile()
     dictionary = readDictionaryFile()
@@ -12,8 +13,8 @@ def encodeFiles(array):
         try:
             input = pickle.load(open(thisfile))
         except ValueError:
-            logging.warn("unable to unpicked " + thisfile + "... dangerously just " + \
-                "skipping, some texts may be lost")
+            logging.warn("unable to unpicked " + thisfile + "... dangerously just " +
+                         "skipping, some texts may be lost")
             continue
         except:
             logging.warn("Some problem: fix if " + thisfile + " should be unpicklable")
@@ -22,14 +23,14 @@ def encodeFiles(array):
             input.encode(level,IDfile,dictionary)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     passedList = sys.argv[1:]
     toEncode = []
     for file in passedList:
         basename = re.sub(".*/","",file)
-        if not os.path.exists(".bookworm/texts/encoded/unigrams/"+basename + ".txt"):
-            if not os.path.exists(".bookworm/texts/encoded/bigrams/"+basename + ".txt"):
+        if not os.path.exists(".bookworm/texts/encoded/unigrams/" + basename + ".txt"):
+            if not os.path.exists(".bookworm/texts/encoded/bigrams/" + basename + ".txt"):
                 toEncode.append(file)
-    logging.info("preparing to encode " + str(len(toEncode)) + " files" + " out of " + \
-        str(len(passedList)))
+    logging.info("preparing to encode " + str(len(toEncode)) + " files" + " out of " +
+                 str(len(passedList)))
     encodeFiles(toEncode)

--- a/bookwormDB/general_API.py
+++ b/bookwormDB/general_API.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from pandas import merge, Series
+from pandas import merge
 from pandas.io.sql import read_sql
 from copy import deepcopy
 from collections import defaultdict

--- a/bookwormDB/ingestFeatureCounts.py
+++ b/bookwormDB/ingestFeatureCounts.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 from tokenizer import *
 import logging

--- a/bookwormDB/manager.py
+++ b/bookwormDB/manager.py
@@ -374,8 +374,7 @@ class BookwormManager(object):
         if you can't connect to the database server.
         """
         import bookwormDB.CreateDatabase
-        import ConfigParser
-        
+
         Bookworm = bookwormDB.CreateDatabase.BookwormSQLDatabase()
         Bookworm.load_word_list()
         Bookworm.create_unigram_book_counts()
@@ -386,7 +385,7 @@ class BookwormManager(object):
         self.database_metadata()
 
 class Extension(object):
-    
+
     """
     A bookworm extension. Initialized with an args object,
     which has the element url, the location of a clonable git repo.
@@ -398,7 +397,7 @@ class Extension(object):
     def __init__(self,args,basedir="./"):
         self.args = args
         self.dir = basedir + ".bookworm/extensions/" + re.sub(".*/","",self.args.url)
-        
+
     def clone_or_pull(self):
         if not os.path.exists(self.dir):
             logging.info("cloning git repo from " + self.args.url)
@@ -406,11 +405,11 @@ class Extension(object):
         else:
             logging.info("updating pre-existing git repo at " + self.dir)
             Popen(["git","pull"],cwd=self.dir)
-            
+ 
     def make(self):
         logging.debug("Running make in " + self.dir)
         Popen(["make"],cwd=self.dir)
-        
+ 
 # Initiate MySQL connection.
 
 
@@ -554,7 +553,7 @@ def run_arguments():
     # Set the logging level based on the input.
     numeric_level = getattr(logging, args.log_level.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError('Invalid log level: %s' % loglevel)
+        raise ValueError('Invalid log level: %s' % args.log_level)
     logging.basicConfig(level=numeric_level)
     # While we're at it, log with line numbers
 

--- a/bookwormDB/printTokenStream.py
+++ b/bookwormDB/printTokenStream.py
@@ -1,6 +1,5 @@
 import sys
 from tokenizer import *
-import warnings
 
 for row in sys.stdin:
     parts = row.split("\t",1)

--- a/bookwormDB/tokenizer.py
+++ b/bookwormDB/tokenizer.py
@@ -215,7 +215,7 @@ class tokenizer(object):
         copies of the text to itself.
         """
         self.tokenize()
-        return zip(*[self.tokens[n:] for n in range(n)])
+        return zip(*[self.tokens[i:] for i in range(n)])
 
     def unigrams(self):
         return self.ngrams(1)
@@ -226,7 +226,6 @@ class tokenizer(object):
     def trigrams(self):
         return self.ngrams(3)
 
-    
     def counts(self,whichType):
         count = dict()
         for gram in getattr(self,whichType)():
@@ -240,7 +239,7 @@ class tokenizer(object):
 class preTokenized(object):
     """
     This class is a little goofy: it mimics the behavior of a tokenizer
-    one data that's already been tokenized by something like 
+    one data that's already been tokenized by something like
     Google Ngrams or JStor Data for Research.
     """
 
@@ -291,15 +290,15 @@ def print_token_stream(input,regex=None,require_ids=True):
     for row in input:
         if require_ids:
             parts = row.split("\t",1)
-            # filename = parts[0]
             try:
                 tokens = tokenizer(parts[1])
             except IndexError:
-                logging.warning("Found no tab in the input for \n" + filename[:50] + "\n...skipping row")
+                logging.warning("Found no tab in the input for row starting with\n" +
+                                row[:50] + "\n...skipping row")
                 continue
         else:
             tokens = tokenizer(row)
-        out= u" ".join(tokens.tokenize())
+        out = u" ".join(tokens.tokenize())
         print out.encode("utf-8")
     
 

--- a/bookwormDB/variableSet.py
+++ b/bookwormDB/variableSet.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import warnings
 import json
 import os
 import decimal
 import re
 from MySQLdb import escape_string
 import logging
-import collections
+import subprocess
+
 
 def to_unicode(obj, encoding='utf-8'):
     if isinstance(obj, basestring):
@@ -27,9 +27,10 @@ def splitMySQLcode(string):
     try:
         output = ['%s;\n' % query for query in string.split(';') if re.search(r"\w", query)]
     except AttributeError:
-        #Occurs when the field is completely empty
+        # Occurs when the field is completely empty
         output = []
     return output
+
 
 class textids(dict):
     """
@@ -60,12 +61,11 @@ class textids(dict):
         for filelist in filelists:
             for line in open(".bookworm/texts/textids/%s" % filelist):
                 parts = line.replace('\n', '').split("\t")
-                if len(parts)==2:
-                    # Allowing terminal newline. 
+                if len(parts) == 2:
+                    # Allowing terminal newline.
                     self[parts[1]] = int(parts[0])
                     numbers.append(int(parts[0]))
 
-                    
         self.new = open('.bookworm/texts/textids/new', 'a')
         self.max = max(numbers)
 
@@ -89,10 +89,10 @@ def guessBasedOnNameAndContents(metadataname,dictionary):
 
     example = dictionary.keys()[0]
 
-    if type(example)==int:
+    if type(example) == int:
         description["type"] = "integer"
-    if type(example)==list:
-        unique(example)==False
+    if type(example) == list:
+        unique(example) == False
 
     if metadataname == "searchstring":
         return {"datatype": "searchstring", "field": "searchstring", "unique": True, "type": "text"}
@@ -101,14 +101,13 @@ def guessBasedOnNameAndContents(metadataname,dictionary):
         description["datatype"] = "time"
 
     values = [dictionary[key] for key in dictionary]
-    averageNumberOfEntries = sum(values)/len(values)
+    averageNumberOfEntries = sum(values) / len(values)
     maxEntries = max(values)
 
     if averageNumberOfEntries > 2:
         description["datatype"] = "categorical"
 
     return description
-
 
 
 class dataField:
@@ -220,35 +219,35 @@ class dataField:
         Builds a disk table for a nonunique variable.
         """
         db = self.dbToPutIn
-        dfield = self;
+        dfield = self
 
         if fileLocation == "default":
             fileLocation = ".bookworm/metadata/" + dfield.field + ".txt"
 
         logging.info("Making a SQL table to hold the data for " + dfield.field)
 
-        q1 = """DROP TABLE IF EXISTS """       + dfield.field + "Disk"
+        q1 = """DROP TABLE IF EXISTS """ + dfield.field + "Disk"
         db.query(q1)
         db.query("""CREATE TABLE IF NOT EXISTS """ + dfield.field + """Disk (
-        """ + self.anchor + " " +  self.anchorType + """,
+        """ + self.anchor + " " + self.anchorType + """,
         """ + dfield.slowSQL(withIndex=True) + """
         );""")
         db.query("ALTER TABLE " + dfield.field + "Disk DISABLE KEYS;")
-        loadcode = """LOAD DATA LOCAL INFILE '""" + fileLocation +  """'
+        loadcode = """LOAD DATA LOCAL INFILE '""" + fileLocation + """'
                INTO TABLE """ + dfield.field + """Disk
                FIELDS ESCAPED BY '';"""
         db.query(loadcode)
-        #cursor = db.query("""SELECT count(*) FROM """ + dfield.field + """Disk""")
+        # cursor = db.query("""SELECT count(*) FROM """ + dfield.field + """Disk""")
         db.query("ALTER TABLE " + dfield.field + "Disk ENABLE KEYS")
 
     def buildIDTable(self):
         IDcode = self.buildIdTable()
         for query in splitMySQLcode(IDcode):
             self.dbToPutIn.query(query)
-        
+
     def buildLookupTable(self):
-        dfield = self;
-        lookupCode = dfield.buildIdTable();
+        dfield = self
+        lookupCode = dfield.buildIdTable()
         lookupCode = lookupCode + dfield.fastSQLTable()
         for query in splitMySQLcode(lookupCode):
             dfield.dbToPutIn.query(query)
@@ -507,8 +506,8 @@ class variableSet:
                 #if it's only one element long, just name it after the variable itself.
                 #Plus the string 'unique', to prevent problems of dual-named tables;
                 self.tableName = "unick_" + self.jsonDefinition[0]['field']
-    
-            self.fastName  = self.tableName + "heap"
+
+            self.fastName = self.tableName + "heap"
 
     def guessAtFieldDescriptions(self,stopAfter=30000):
         allMyKeys = dict()
@@ -657,7 +656,7 @@ class variableSet:
                 #It can get problematic to have them both, so we're just writing over the
                 #anchorField here.
                 mainfields = [str(bookid)]
-            #First, pull the unique variables and write them to the 'catalog' table
+            # First, pull the unique variables and write them to the 'catalog' table
             for var in [variable for variable in variables if variable.unique]:
                 if var.field not in [self.anchorField,self.fastAnchor]:
                     myfield = entry.get(var.field, "")
@@ -666,9 +665,9 @@ class variableSet:
                     mainfields.append(to_unicode(myfield))
             catalogtext = '%s\n' % '\t'.join(mainfields)
             catalog.write(catalogtext.encode('utf-8'))
-                
+
             for variable in [variable for variable in variables if not variable.unique]:
-                 #Each of these has a different file it must write to...
+                # Each of these has a different file it must write to...
                 outfile = variable.output
                 lines = entry.get(variable.field, [])
                 if isinstance(lines,(basestring,int)):
@@ -686,7 +685,7 @@ class variableSet:
                         logging.warning("some sort of error with bookid no. " +str(bookid) + ": " + json.dumps(lines))
                         pass
             if linenum > limit:
-               break
+                break
             linenum=linenum+1
         for variable in [variable for variable in variables if not variable.unique]:
             variable.output.close()
@@ -735,10 +734,10 @@ class variableSet:
                 anchorFields = "bookid,filename"
                 
             loadEntries = {
-                "catLoc" : self.catalogLocation,
-                "tabName" : self.tableName,
-                "anchorFields" : anchorFields,
-                "loadingFields" :  anchorFields+ "," + ','.join([field.field for field in self.variables if field.unique])
+                "catLoc": self.catalogLocation,
+                "tabName": self.tableName,
+                "anchorFields": anchorFields,
+                "loadingFields": anchorFields + "," + ','.join([field.field for field in self.variables if field.unique])
             }
 
             loadEntries['loadingFields'] = loadEntries['loadingFields'].rstrip(',')
@@ -785,7 +784,7 @@ class variableSet:
             # Make sure the variables know who their parent is
             variable.fastAnchor = self.fastAnchor
             # Update the referents for everything
-            variable.updateVariableDescriptionTable();
+            variable.updateVariableDescriptionTable()
 
         inCatalog = self.uniques()
         if len(inCatalog) > 0 and self.tableName!="catalog":

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=0
+
+[flake8]
+ignore= E231, E501

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='bookwormDB',
       # Copy the cgi-executable to a cgi-dir.
       classifiers=[
         'Development Status :: 4 - Beta',
-
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         "Natural Language :: English",
@@ -45,5 +44,4 @@ setup(name='bookwormDB',
         "Topic :: Text Processing :: Linguistic"
         ],
       install_requires= ["numpy","regex","nltk","numpy","pandas","mysql-python","python-dateutil"]
-      
 )


### PR DESCRIPTION
@bmschmidt: I rebased all my commits into one squashed commit, so that it doesn't clog up the BW commit history. I still have the original 9 commits locally if you prefer that.

This is the more important or less drastic fixes moving toward https://github.com/Bookworm-project/BookwormDB/issues/98. The remaining issues I think we can tackle incidentally during other work rather than a big 'pulling the band-aid' correction. I mainly wanted to get the codebase to a place where it's easier to spot potential bugs by sight. This process already helped find some breaking bugs, like three references to variables that aren't set.

Below is the commit message for this pull request.

---
Adding some errors to ignore list, and fixing the following
warnings/errors

- F401: unused imports
- F812: list comprehension potentially redefining out-of-scope variable
- F841: undefined variables called
- F811: double imports
- E70*: Multiple statements per line and ending semicolons
- E10* and E50*: Indentation and backslash style issues
- E221, E222, E241: Unexpected multiple spaces
- E201, E203: More unexpected whitespace