### PR TITLE
HTRC improvements

### DIFF
--- a/bookwormDB/manager.py
+++ b/bookwormDB/manager.py
@@ -384,20 +384,23 @@ class BookwormManager(object):
         """
         import bookwormDB.CreateDatabase
         
-        newtable, ingest, close = True, True, True
+        index = True
+        ingest = True
+        newtable = True
+
         if cmd_args:
-            if cmd_args.close_only:
+            if cmd_args.index_only:
                 ingest = False
                 netable = False
             else:
-                close = not cmd_args.no_close
+                index = not cmd_args.no_index
                 newtable = not cmd_args.no_delete
-            if not (newtable and ingest and close): 
+            if not (newtable and ingest and index): 
                 logging.warn("database_wordcounts args not supported for bigrams yet.")
 
         Bookworm = bookwormDB.CreateDatabase.BookwormSQLDatabase()
         Bookworm.load_word_list()
-        Bookworm.create_unigram_book_counts(newtable=newtable, ingest=ingest, close=close)
+        Bookworm.create_unigram_book_counts(newtable=newtable, ingest=ingest, index=index)
         Bookworm.create_bigram_book_counts()
 
     def database(self):
@@ -556,8 +559,8 @@ def run_arguments():
     word_ingest_parser = extensions_subparsers.add_parser("database_wordcounts",
                                                            help=getattr(BookwormManager, "database_wordcounts").__doc__)
     word_ingest_parser.add_argument("--no-delete", action="store_true", help="Do not delete and rebuild the token tables. Useful for a partially finished ingest.")
-    word_ingest_parser.add_argument("--no-close", action="store_true", help="Do not re-enable keys after ingesting tokens. Only do this if you intent to manually enable keys or will run this command again.")
-    word_ingest_parser.add_argument("--close-only", action="store_true", help="Only re-enable keys. Supercedes other flags.")
+    word_ingest_parser.add_argument("--no-index", action="store_true", help="Do not re-enable keys after ingesting tokens. Only do this if you intent to manually enable keys or will run this command again.")
+    word_ingest_parser.add_argument("--index-only", action="store_true", help="Only re-enable keys. Supercedes other flags.")
     # Bookworm prep targets that don't allow additional args
     for prep_arg in ['text_id_database', 'catalog_metadata', 'database_metadata', 'guessAtFieldDescriptions']:
         extensions_subparsers.add_parser(prep_arg, help=getattr(BookwormManager, prep_arg).__doc__)

--- a/bookwormDB/manager.py
+++ b/bookwormDB/manager.py
@@ -233,7 +233,7 @@ class BookwormManager(object):
 
         That's a little groaty, I know.
         """
-        logging.debug(cmd_args)
+        logging.debug(args)
         getattr(self,args.goal)(cmd_args=args)
         
     def build(self,args):

--- a/bookwormDB/manager.py
+++ b/bookwormDB/manager.py
@@ -23,8 +23,6 @@ for the command-line executable,
 even though it's not best practice otherwise.
 """
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', datefmt="%d/%Y %H:%M:%S")
-
 class BookwormManager(object):
     """
     This class is passed some options that tell it the name of the bookworm it's working on;
@@ -571,11 +569,11 @@ def run_arguments():
     numeric_level = getattr(logging, args.log_level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % args.log_level)
-    logging.basicConfig(level=numeric_level)
     # While we're at it, log with line numbers
-
-    FORMAT = "[%(filename)s:%(lineno)s - %(funcName)25s() ] %(message)s"
-    logging.basicConfig(format=FORMAT)
+    FORMAT = "[%(%(filename)s:%(lineno)s-%(funcName)25s()] %(message)s"
+    logging.basicConfig(format=FORMAT, level=numeric_level)
+    logging.info("Info logging enabled.")
+    logging.info("Debug logging enabled.")
 
     # Create the bookworm 
     my_bookworm = BookwormManager(args.configuration,args.database)

--- a/bookwormDB/manager.py
+++ b/bookwormDB/manager.py
@@ -391,7 +391,7 @@ class BookwormManager(object):
         if cmd_args:
             if cmd_args.index_only:
                 ingest = False
-                netable = False
+                newtable = False
             else:
                 index = not cmd_args.no_index
                 newtable = not cmd_args.no_delete


### PR DESCRIPTION
This bundles a couple of changes that were done around the same time.

- Fixing the broken logging, as per #133 
- Adding `--index-only`, `--no-index`, and `--no-delete` flags to `bookworm prep database_wordcounts`, resolving #135 (and fixing one bug that came up).
- Two small improvements: `db.query()` supports `executemany` calls, and there is a backup process for writing csv files to DB from Python if LOAD DATA INFILE fails. Not sure when this might be useful except with a permission error - I wrote it for some benchmarking and figured it could be kept in as a failsafe.
- Support for ingest from `h5` files. This looks for a table called `unigrams` inside the file, writes a set of temporary CSVs in parallel, then uses LOAD DATA INFILE. The reason I opted for H5 is because it's well supported in Pandas and contains support for 'blosc', a fast compression algorithm. I tried to keep this code as simple as possible, it would have been easy to over-engineer it.
- I started generalizing `create_unigram_book_counts`, toward eventually being able to convert it to a `create_book_counts_table` method that `create_unigram_book_counts` and `create_bigram_book_counts` can both use. This relates to the discussion in #134. Updates above are currently specific to unigram tables, my use case, so this will allow bigrams indexes to keep pace.